### PR TITLE
update pandas api name from config to smart_pandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ data = pd.DataFrame(
         "life_expectancy": [80, 80, 80],
     }
 )
-data.config.init(config_path="examples/example_config.yaml")
+data.smart_pandas.init(config_path="examples/example_config.yaml")
 
-print(data.config.raw_features)
+print(data.smart_pandas.raw_features)
 
 #
 #        weight  height  age

--- a/examples/example.py
+++ b/examples/example.py
@@ -11,9 +11,9 @@ data = pd.DataFrame(
         "life_expectancy": [80, 80, 80],
     }
 )
-data.config.init(config_path="examples/example_config.yaml")
+data.smart_pandas.init(config_path="examples/example_config.yaml")
 
-print(data.config.raw_features)
+print(data.smart_pandas.raw_features)
 """
        weight  height  age
 0      78     180   31

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -9,6 +9,12 @@
       description: "Unique identifier for the person"
     },
     {
+      name: "timestamp",
+      schema: {"dtype": "datetime"},
+      tags: ["row_timestamp"],
+      description: "Timestamp of the data"
+    },
+    {
       name: "name",
       schema: {"dtype": "str"},
       tags: ["metadata"],

--- a/examples/schema_example.py
+++ b/examples/schema_example.py
@@ -11,20 +11,20 @@ data = pd.DataFrame(
         "life_expectancy": [80, 80, 80],
     }
 )
-data.config.init(config_path="examples/example_config.yaml")
+data.smart_pandas.init(config_path="examples/example_config.yaml")
 data["bmi"] = data["weight"] / (data["height"] / 100) ** 2
 
-print(type(data.config.schema))  # smart-pandas constructs a pandera DataFrameSchema
+print(type(data.smart_pandas.schema))  # smart-pandas constructs a pandera DataFrameSchema
 """
 <class 'pandera.api.pandas.container.DataFrameSchema'>
 """
 
 validated_data = (
-    data.config.validate()
+    data.smart_pandas.validate()
 )  # runs validation using the pandera DataFrameSchema
 
 # validated_data still has the smart-pandas config attached
-print(validated_data.config.raw_features)
+print(validated_data.smart_pandas.raw_features)
 """
        weight  height  age
 0      78     180   31

--- a/smart_pandas/data_config.py
+++ b/smart_pandas/data_config.py
@@ -5,13 +5,25 @@ from smart_pandas.schema_utils import default_df_schema_params
 
 
 class DataConfig(BaseModel):
+    """
+    Config object for a dataset.
+
+    The config allows validation of column names and types, as well as attributes for extracting specific columns.
+
+    Parameters
+    ----------
+    name: str
+        The name of the dataset.
+    column_set: ColumnSet
+        The column set of the dataset.
+    """
     name: str
     column_set: ColumnSet
 
     @property
     def raw_features(self):
         return [
-            column.name for column in self.column_set 
+            column.name for column in self.column_set
             if any(tag.name == "raw_feature" for tag in column.tags)
         ]
 
@@ -34,8 +46,29 @@ class DataConfig(BaseModel):
     @property
     def target(self):
         return [
-            column.name for column in self.column_set 
+            column.name for column in self.column_set
             if any(tag.name == "target" for tag in column.tags)
+        ] or None
+
+    @property
+    def unique_identifier(self):
+        return [
+            column.name for column in self.column_set
+            if any(tag.name == "unique_identifier" for tag in column.tags)
+        ] or None
+
+    @property
+    def metadata(self):
+        return [
+            column.name for column in self.column_set
+            if any(tag.name == "metadata" for tag in column.tags)
+        ] or None
+
+    @property
+    def row_timestamp(self):
+        return [
+            column.name for column in self.column_set
+            if any(tag.name == "row_timestamp" for tag in column.tags)
         ] or None
 
     @property

--- a/smart_pandas/smart_pandas.py
+++ b/smart_pandas/smart_pandas.py
@@ -5,43 +5,57 @@ from smart_pandas.column_set import ColumnSet
 from smart_pandas.config_utils import read_config
 
 
-@pd.api.extensions.register_dataframe_accessor("config")
+@pd.api.extensions.register_dataframe_accessor("smart_pandas")
 class SmartPandas:
+    """Pandas API extension for smart pandas."""
     def __init__(self, pandas_obj):
         self._obj = pandas_obj
 
     def init(
         self, config_path: Optional[str] = None, config: Optional[ColumnSet] = None
     ):
+        """Initialise the config for the dataframe via either a config path or a config object."""
         if config is None:
             if config_path is None:
                 raise ValueError("Either config or config_path must be provided")
             config = read_config(config_path)
-        self.config = config
+        self.smart_pandas = config
 
     @property
     def name(self):
-        return self.config.name
+        return self.smart_pandas.name
 
     @property
     def raw_features(self):
-        return self._obj[self.config.raw_features]
+        return self._obj[self.smart_pandas.raw_features]
 
     @property
     def derived_features(self):
-        return self._obj[self.config.derived_features]
+        return self._obj[self.smart_pandas.derived_features]
 
     @property
     def model_features(self):
-        return self._obj[self.config.model_features]
+        return self._obj[self.smart_pandas.model_features]
 
     @property
     def target(self):
-        return self._obj[self.config.target]
+        return self._obj[self.smart_pandas.target]
+
+    @property
+    def unique_identifier(self):
+        return self._obj[self.smart_pandas.unique_identifier]
+
+    @property
+    def metadata(self):
+        return self._obj[self.smart_pandas.metadata]
+
+    @property
+    def row_timestamp(self):
+        return self._obj[self.smart_pandas.row_timestamp]
 
     @property
     def schema(self):
-        return self.config.schema
+        return self.smart_pandas.schema
 
     def validate(self, inplace: bool = False, **kwargs):
         """
@@ -60,10 +74,10 @@ class SmartPandas:
             The validated DataFrame. If inplace is True, returns None.
         """
         if inplace:
-            self.config.schema.validate(self._obj, inplace=inplace, **kwargs)
+            self.smart_pandas.schema.validate(self._obj, inplace=inplace, **kwargs)
             return None
-        validated_data = self.config.schema.validate(
+        validated_data = self.smart_pandas.schema.validate(
             self._obj, inplace=inplace, **kwargs
         )
-        validated_data.config.init(config=self.config)
+        validated_data.smart_pandas.init(config=self.smart_pandas)
         return validated_data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,6 @@ def smart_data():
             "life_expectancy": [80, 80, 80],
         }
     )
-    smart_data.config.init(config_path="examples/example_config.yaml")
+    smart_data.smart_pandas.init(config_path="examples/example_config.yaml")
     smart_data["bmi"] = smart_data["weight"] / (smart_data["height"] / 100) ** 2
     return smart_data

--- a/tests/test_smart_pandas.py
+++ b/tests/test_smart_pandas.py
@@ -3,24 +3,24 @@ import pandas as pd
 
 def test_config_ingestion(smart_data):
 
-    assert smart_data.config.name == "life_expectancy_modelling_data"
+    assert smart_data.smart_pandas.name == "life_expectancy_modelling_data"
 
     pd.testing.assert_frame_equal(
-        smart_data.config.raw_features, smart_data[["weight", "height", "age"]]
+        smart_data.smart_pandas.raw_features, smart_data[["weight", "height", "age"]]
     )
 
     pd.testing.assert_frame_equal(
-        smart_data.config.raw_features, smart_data[["weight", "height", "age"]]
+        smart_data.smart_pandas.raw_features, smart_data[["weight", "height", "age"]]
     )
 
     pd.testing.assert_frame_equal(
-        smart_data.config.derived_features, smart_data[["bmi"]]
+        smart_data.smart_pandas.derived_features, smart_data[["bmi"]]
     )
 
     pd.testing.assert_frame_equal(
-        smart_data.config.model_features, smart_data[["age", "bmi"]]
+        smart_data.smart_pandas.model_features, smart_data[["age", "bmi"]]
     )
 
     pd.testing.assert_frame_equal(
-        smart_data.config.target, smart_data[["life_expectancy"]]
+        smart_data.smart_pandas.target, smart_data[["life_expectancy"]]
     )


### PR DESCRIPTION
# What?
- Update the pandas config name from `config` to `smart_pandas` to make it more package specific. Config is a little too generic, it should be clear we are accessing utilities added by the smart-pandas package.
- Added some additional attributes for the smart-pandas config